### PR TITLE
Fix create data problem : missing sample_index and camera_intrinsics …

### DIFF
--- a/mmdet3d/datasets/nuscenes_dataset.py
+++ b/mmdet3d/datasets/nuscenes_dataset.py
@@ -211,6 +211,7 @@ class NuScenesDataset(Custom3DDataset):
 
         data = dict(
             token=info["token"],
+            sample_idx=info['token'],
             lidar_path=info["lidar_path"],
             sweeps=info["sweeps"],
             timestamp=info["timestamp"],
@@ -251,7 +252,7 @@ class NuScenesDataset(Custom3DDataset):
 
                 # camera intrinsics
                 camera_intrinsics = np.eye(4).astype(np.float32)
-                camera_intrinsics[:3, :3] = camera_info["cam_intrinsic"]
+                camera_intrinsics[:3, :3] = camera_info["camera_intrinsics"]
                 data["camera_intrinsics"].append(camera_intrinsics)
 
                 # lidar to image transform


### PR DESCRIPTION
Fix create data problem
## fix issue #11 
the issue is :
File "bevfusion/tools/data_converter/create_gt_database.py", line 275, in create_groundtruth_database
    image_idx = example["sample_idx"]
KeyError: 'sample_idx'

## fix camera_intrinsics key problem 
camera_intrinsics[:3, :3] = camera_info["cam_intrinsic"] ===> camera_intrinsics[:3, :3] = camera_info["camera_intrinsics"]
