### PR TITLE
[fix] fix bug for issue#29

### DIFF
--- a/mmdet3d/models/vtransforms/base.py
+++ b/mmdet3d/models/vtransforms/base.py
@@ -183,6 +183,7 @@ class BaseTransform(nn.Module):
         camera_intrinsics,
         img_aug_matrix,
         lidar_aug_matrix,
+        metas=None,
         **kwargs,
     ):
         rots = camera2ego[..., :3, :3]


### PR DESCRIPTION
The parameters of `BaseTransform`'s `forward()` funciton seem to be wrong, which leads to fail to visualize the seg results of camera-only and fusion models. 
This PR is for issue #29.