### PR TITLE
[debug] fix bug for benchmark

### DIFF
--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -7,7 +7,8 @@ from mmcv.runner import load_checkpoint, wrap_fp16_model
 
 from mmdet3d.datasets import build_dataloader, build_dataset
 from mmdet3d.models import build_fusion_model
-
+from torchpack.utils.config import configs
+from mmdet3d.utils import recursive_eval
 
 def parse_args():
     parser = argparse.ArgumentParser(description="MMDet benchmark a model")
@@ -19,11 +20,11 @@ def parse_args():
     args = parser.parse_args()
     return args
 
-
 def main():
     args = parse_args()
 
-    cfg = Config.fromfile(args.config)
+    configs.load(args.config, recursive=True)
+    cfg = Config(recursive_eval(configs), filename=args.config)
     # set cudnn_benchmark
     if cfg.get("cudnn_benchmark", False):
         torch.backends.cudnn.benchmark = True


### PR DESCRIPTION
I tried to test inference time of the models, and run `python tools/benchmark.py`.
However, AttributeError occurs in `benchmark.py`, shown as below.
```
Traceback (most recent call last):
  File "tools/benchmark.py", line 88, in <module>
    main()
  File "tools/benchmark.py", line 31, in main
    cfg.data.test.test_mode = True
  File "/home/ubuntu/anaconda3/envs/bev_fusion/lib/python3.8/site-packages/mmcv/utils/config.py", line 507, in __getattr__
    return getattr(self._cfg_dict, name)
  File "/home/ubuntu/anaconda3/envs/bev_fusion/lib/python3.8/site-packages/mmcv/utils/config.py", line 48, in __getattr__
    raise ex
AttributeError: 'ConfigDict' object has no attribute 'data'
```
This is caused by the misuse of `ConfigDict`.
This PR is related with #14 