### PR TITLE
Add docker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,33 @@ After installing these dependencies, please run this command to install the code
 python setup.py develop
 ```
 
+We also provide a [Dockerfile](docker/Dockerfile) to ease environment setup. To get started with docker, please make sure that `nvidia-docker` is installed on your machine. After that, please execute the following command to build the docker image:
+
+```bash
+cd docker && docker build .
+```
+
+After building the image, you will be able to see its id via:
+
+```bash
+docker image ls
+```
+
+We can then run the docker with the following command:
+
+```bash
+nvidia-docker run -it -v [dataset directory]:/dataset --shm-size 16g [image size]  /bin/bash
+```
+
+We recommend the users to run data preparation (instructions are available in the next section) outside the docker if possible. Within the docker, please run the following command to clone our repo and install custom CUDA extensions:
+
+```bash
+cd home && git clone https://github.com/mit-han-lab/bevfusion && cd bevfusion
+python setup.py develop
+```
+
+You can then create a symbolic link to the `/dataset` directory. Please make sure that `data/nuscenes` contains the nuScenes dataset.
+
 ### Data Preparation
 
 #### nuScenes

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ cd home && git clone https://github.com/mit-han-lab/bevfusion && cd bevfusion
 python setup.py develop
 ```
 
-You can then create a symbolic link to the `/dataset` directory. Please make sure that `data/nuscenes` contains the nuScenes dataset.
+You can then create a symbolic link `data` to the `/dataset` directory in the docker.
 
 ### Data Preparation
 

--- a/README.md
+++ b/README.md
@@ -73,22 +73,16 @@ python setup.py develop
 We also provide a [Dockerfile](docker/Dockerfile) to ease environment setup. To get started with docker, please make sure that `nvidia-docker` is installed on your machine. After that, please execute the following command to build the docker image:
 
 ```bash
-cd docker && docker build .
-```
-
-After building the image, you will be able to see its id via:
-
-```bash
-docker image ls
+cd docker && docker build . -t bevfusion
 ```
 
 We can then run the docker with the following command:
 
 ```bash
-nvidia-docker run -it -v [dataset directory]:/dataset --shm-size 16g [image size]  /bin/bash
+nvidia-docker run -it -v `pwd`/../data:/dataset --shm-size 16g bevfusion /bin/bash
 ```
 
-We recommend the users to run data preparation (instructions are available in the next section) outside the docker if possible. Within the docker, please run the following command to clone our repo and install custom CUDA extensions:
+We recommend the users to run data preparation (instructions are available in the next section) outside the docker if possible. Note that the dataset directory should be an absolute path. Within the docker, please run the following command to clone our repo and install custom CUDA extensions:
 
 ```bash
 cd home && git clone https://github.com/mit-han-lab/bevfusion && cd bevfusion

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,23 @@
+FROM nvidia/cuda:11.3.1-devel-ubuntu20.04
+
+RUN apt-get update && apt-get install wget -yq
+RUN apt-get install build-essential g++ gcc -y
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get install libgl1-mesa-glx libglib2.0-0 -y
+RUN apt-get install openmpi-bin openmpi-common libopenmpi-dev libgtk2.0-dev git -y
+
+# Install miniconda
+ENV CONDA_DIR /opt/conda
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
+     /bin/bash ~/miniconda.sh -b -p /opt/conda
+# Put conda in path so we can use conda activate
+ENV PATH=$CONDA_DIR/bin:$PATH
+RUN conda install python=3.8
+RUN conda install pytorch==1.10.1 torchvision==0.11.2 torchaudio==0.10.1 cudatoolkit=11.3 -c pytorch
+RUN pip install Pillow==8.4.0
+RUN pip install tqdm
+RUN pip install torchpack
+RUN pip install mmcv==1.4.0 mmcv-full==1.4.0 mmdet==2.20.0
+RUN pip install nuscenes-devkit
+RUN pip install mpi4py==3.0.3
+RUN pip install numba==0.48.0


### PR DESCRIPTION
This is related to [PR](https://github.com/mit-han-lab/bevfusion/pull/144) from @bentherien. 

We provide an alternative to let the users build the docker image by themselves. The required libraries and their versions are clearly listed in `docker/Dockerfile`. Hopefully this will also be helpful for people who are trying to set up the environment in the host machines by themselves.

I am also plan to merge [PR](https://github.com/mit-han-lab/bevfusion/pull/144) after this one.