### PR TITLE
Removed gt_masks_bev from prediction cycle

### DIFF
--- a/mmdet3d/models/fusion_models/bevfusion.py
+++ b/mmdet3d/models/fusion_models/bevfusion.py
@@ -297,7 +297,6 @@ class BEVFusion(Base3DFusionModel):
                         outputs[k].update(
                             {
                                 "masks_bev": logits[k].cpu(),
-                                "gt_masks_bev": gt_masks_bev[k].cpu(),
                             }
                         )
                 else:


### PR DESCRIPTION
Like in 3d bbox prediction only output of model should be added in the outputs dictionary during prediction

Fix for issue #429 

Refered the flow in bbox to confirm that the fix is valid
https://github.com/mit-han-lab/bevfusion/blob/db75150717a9462cb60241e36ba28d65f6908607/mmdet3d/models/fusion_models/bevfusion.py#L287-L293
Because here too, the ground truth values are not added to the output dictionary.